### PR TITLE
feat: implement session table and UUID-based token login

### DIFF
--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,2 +1,3 @@
 // Export all table definitions here
 export * from "./users";
+export * from "./sessions";

--- a/src/db/schema/sessions.ts
+++ b/src/db/schema/sessions.ts
@@ -1,0 +1,9 @@
+import { mysqlTable, serial, varchar, timestamp, bigint } from "drizzle-orm/mysql-core";
+import { users } from "./users";
+
+export const sessions = mysqlTable("sessions", {
+  id: serial("id").primaryKey(),
+  token: varchar("token", { length: 255 }).notNull(),
+  userId: bigint("user_id", { mode: "number", unsigned: true }).notNull().references(() => users.id),
+  createdAt: timestamp("created_at").defaultNow(),
+});

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -5,6 +5,5 @@ export const users = mysqlTable("users", {
   username: varchar("username", { length: 255 }).notNull(),
   email: varchar("email", { length: 255 }).notNull().unique(),
   password: varchar("password", { length: 255 }).notNull(),
-  token: varchar("token", { length: 255 }),
   createdAt: timestamp("created_at").defaultNow(),
 });

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -1,5 +1,5 @@
 import { db } from "../db";
-import { users } from "../db/schema";
+import { users, sessions } from "../db/schema";
 import { eq } from "drizzle-orm";
 
 export class UsersService {
@@ -56,27 +56,38 @@ export class UsersService {
       throw new Error("Email atau password salah");
     }
 
-    // 3. Return user (excluding password)
-    const { password: _, ...userWithoutPassword } = user;
+    // 3. Generate UUID token and save to sessions table
+    const token = crypto.randomUUID();
 
-    return { data: userWithoutPassword };
+    await db.insert(sessions).values({
+      token,
+      userId: user.id,
+    });
+
+    return { data: token };
   }
 
   async getCurrentUser(token: string) {
-    // 1. Check if user exists by token
-    const existingUser = await db
-      .select()
-      .from(users)
-      .where(eq(users.token, token))
+    // 1. Find session by token and join with users table
+    const result = await db
+      .select({
+        id: users.id,
+        username: users.username,
+        email: users.email,
+        createdAt: users.createdAt,
+      })
+      .from(sessions)
+      .innerJoin(users, eq(sessions.userId, users.id))
+      .where(eq(sessions.token, token))
       .limit(1);
 
-    const user = existingUser[0];
+    const user = result[0];
 
     if (!user) {
       throw new Error("Unauthorized");
     }
 
-    // 2. Return user details (without sensitive fields like password or token)
+    // 2. Return user details (without sensitive fields)
     return {
       data: {
         id: user.id,


### PR DESCRIPTION
Closes #7

Implement session-based authentication:
- Add sessions table with UUID token, user_id FK, and createdAt
- Remove token column from users table
- Update loginUser to generate UUID and save to sessions table
- Update getCurrentUser to join sessions with users by token